### PR TITLE
feat: create post_save signal for auto group assignment

### DIFF
--- a/users/apps.py
+++ b/users/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     name = 'users'
+
+    def ready(self):
+        import users.signals  # noqa: F401

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import Group
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import User
+
+
+ROLE_GROUPS = {
+    'vendor_admin',
+    'store_staff',
+    'customer',
+}
+
+
+@receiver(post_save, sender=User)
+def assign_role_group_on_create(sender, instance, created, **kwargs):
+    if not created or instance.role not in ROLE_GROUPS:
+        return
+
+    group, _ = Group.objects.get_or_create(name=instance.role)
+    instance.groups.add(group)

--- a/users/tests.py
+++ b/users/tests.py
@@ -29,6 +29,41 @@ class RoleGroupMigrationTests(APITestCase):
         self.assertEqual(existing_groups, expected_groups)
 
 
+class RoleGroupAssignmentTests(APITestCase):
+    def test_user_is_auto_assigned_group_matching_role_on_creation(self):
+        roles = [
+            'vendor_admin',
+            'store_staff',
+            'customer',
+        ]
+
+        for role in roles:
+            with self.subTest(role=role):
+                user = User.objects.create_user(
+                    email=f'{role}@example.com',
+                    password='StrongPass123',
+                    first_name='Role',
+                    last_name='User',
+                    role=role,
+                )
+
+                self.assertTrue(user.groups.filter(name=role).exists())
+
+    def test_superadmin_is_not_assigned_managed_role_group(self):
+        user = User.objects.create_superuser(
+            email='superadmin@example.com',
+            password='StrongPass123',
+            first_name='Super',
+            last_name='Admin',
+        )
+
+        self.assertFalse(
+            user.groups.filter(
+                name__in=['vendor_admin', 'store_staff', 'customer']
+            ).exists()
+        )
+
+
 class JwtClaimsTests(APITestCase):
     def setUp(self):
         self.tenant = Tenant.objects.create(


### PR DESCRIPTION
## What this does
- Creates post_save signal on User model
- Auto-assigns Django group based on user role on creation

## Related Epic
Epic 1.2 - Role-Based Access Control & Permissions

## Related Story
System enforces role-based access on all endpoints